### PR TITLE
OSX Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,12 @@
 
 ## Description
 
-This Puppet module will install [awscli](https://github.com/aws/aws-cli). It is works with Debian and RedHat based distros.
+This Puppet module will install [awscli](https://github.com/aws/aws-cli). It is works with Debian, RedHat and OSX(Tested on Yosemite using boxen) based distros.
+
+OSX has been tested on Yosemite only and requires:
+- boxen https://boxen.github.com
+- boxen homebrew https://github.com/boxen/puppet-homebrew.
+- Packages python and brew-pip are require to be install using boxen. 
 
 ## Installation
 

--- a/manifests/deps.pp
+++ b/manifests/deps.pp
@@ -18,6 +18,9 @@ class awscli::deps {
     'RedHat': {
       include awscli::deps::redhat
     }
+    'Darwin': {
+      include awscli::deps::osx
+    }
     default:  { fail('The awscli module currently only suports Debian and RedHat families') }
   }
 }

--- a/manifests/deps/osx.pp
+++ b/manifests/deps/osx.pp
@@ -1,0 +1,8 @@
+# ==Class: awscli::deps::osx
+#
+# This module manages awscli dependencies for Darwin $::osfamily.
+#
+class awscli::deps::osx {
+  if ! defined(Package['python']) { package { 'python': ensure => installed, provider => homebrew } }
+  if ! defined(Package['brew-pip']) { package { 'brew-pip': ensure => installed, provider => homebrew } }
+}


### PR DESCRIPTION
This pull request contains support for osx using boxen.
Boxen is a nice project that quickly enables the use of puppet on Mac OSX systems.
However puppet modules written for boxen are usually only supported for Mac OSX systems.
Puppet should work in any system, so in my efforts to integrate puppet modules I use in boxen, I am trying to add osx support on existing modules like this.