### PR TITLE
adds a define for adding awscli profiles

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,5 +2,7 @@
 fixtures:
   repositories:
     epel: https://github.com/stahnma/puppet-module-epel
+    concat: https://github.com/puppetlabs/puppetlabs-concat
+    stdlib: http://github.com/puppetlabs/puppetlabs-stdlib
   symlinks:
     awscli: "#{source_dir}"

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -1,8 +1,13 @@
 FORGE
   remote: https://forgeapi.puppetlabs.com
   specs:
+    puppetlabs-concat (1.2.0)
+      puppetlabs-stdlib (< 5.0.0, >= 3.2.0)
+    puppetlabs-stdlib (4.5.1)
     stahnma-epel (1.0.2)
 
 DEPENDENCIES
+  puppetlabs-concat (< 2.0.0, >= 1.0.0)
+  puppetlabs-stdlib (< 5.0.0, >= 4.0.0)
   stahnma-epel (< 2.0.0, >= 1.0.0)
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,31 @@ OSX has been tested on Yosemite only and requires:
 
 `class { 'awscli': }`
 
+### Profiles
+
+If you want to add a credentials for awscli you can do it by using awscli::profile:
+
+If you just define access_key_id and secret key, these credentials will work only for the root user:
+
+```
+awscli::profile {
+  'default':
+    aws_access_key_id     => 'MYAWSACCESSKEYID',
+    aws_secret_access_key => 'MYAWSSECRETACESSKEY'
+}
+```
+
+You can also define a profile for a custom user:
+
+```
+awscli::profile {
+  'default':
+    user                  => 'ubuntu',
+    aws_access_key_id     => 'MYAWSACCESSKEYID',
+    aws_secret_access_key => 'MYAWSSECRETACESSKEY'
+}
+```
+
 ## Testing
 You can test this module with rspec:
 

--- a/manifests/profile.pp
+++ b/manifests/profile.pp
@@ -1,0 +1,51 @@
+# == Define: awscli::profile
+#
+# Puts a profile into the awscred file
+#
+# === Options
+#
+# [*aws_access_key_id*]
+#    The aws_access_key_id for this profile
+#
+# [*aws_secret_access_key*]
+#    The aws_secret_access_key for this profile
+#
+define awscli::profile(
+  $user                  = 'root',
+  $aws_access_key_id     = undef,
+  $aws_secret_access_key = undef,
+) {
+  if $aws_access_key_id == undef {
+    fail ('no aws_access_key_id provided')
+  }
+
+  if $aws_secret_access_key == undef {
+    fail ('no aws_secret_access_key provided')
+  }
+
+  if $user != 'root' {
+    $homedir = "/home/$user"
+  } else {
+    $homedir = "/root"
+  }
+
+  if !defined(File["homedir/.aws"]) {
+    file { "$homedir/.aws":
+      ensure => 'directory'
+    }
+  }
+
+  if !defined(Concat["$homedir/.aws/credentials"]) {
+    concat { "$homedir/.aws/credentials":
+      ensure => 'present'
+    }
+  }
+
+
+  concat::fragment{ "$title":
+    target  => "$homedir/.aws/credentials",
+    content => "[$title]\naws_access_key_id=$aws_access_key_id\naws_secret_access_key=$aws_secret_access_key\n\n",
+  }
+}
+
+

--- a/manifests/profile.pp
+++ b/manifests/profile.pp
@@ -4,6 +4,8 @@
 #
 # === Options
 #
+# [*user*]
+#    The user for whom the profile will be installed
 # [*aws_access_key_id*]
 #    The aws_access_key_id for this profile
 #
@@ -24,27 +26,29 @@ define awscli::profile(
   }
 
   if $user != 'root' {
-    $homedir = "/home/$user"
+    $homedir = "/home/${user}"
   } else {
-    $homedir = "/root"
+    $homedir = '/root'
   }
 
-  if !defined(File["homedir/.aws"]) {
-    file { "$homedir/.aws":
+  if !defined(File["${homedir}/.aws"]) {
+    file { "${homedir}/.aws":
       ensure => 'directory'
+      owner  => $user,
+      group  => $user
     }
   }
 
-  if !defined(Concat["$homedir/.aws/credentials"]) {
-    concat { "$homedir/.aws/credentials":
+  if !defined(Concat["${homedir}/.aws/credentials"]) {
+    concat { "${homedir}/.aws/credentials":
       ensure => 'present'
     }
   }
 
 
-  concat::fragment{ "$title":
-    target  => "$homedir/.aws/credentials",
-    content => "[$title]\naws_access_key_id=$aws_access_key_id\naws_secret_access_key=$aws_secret_access_key\n\n",
+  concat::fragment{ $title:
+    target  => "${homedir}/.aws/credentials",
+    content => template('awscli/credentials_concat.erb')
   }
 }
 

--- a/manifests/profile.pp
+++ b/manifests/profile.pp
@@ -33,7 +33,7 @@ define awscli::profile(
 
   if !defined(File["${homedir}/.aws"]) {
     file { "${homedir}/.aws":
-      ensure => 'directory'
+      ensure => 'directory',
       owner  => $user,
       group  => $user
     }

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,9 @@
   "source": "https://github.com/justindowning/puppet-awscli.git",
   "issues_url": "https://github.com/justindowning/puppet-awscli/issues",
   "dependencies": [
-    { "name": "stahnma/epel",  "version_requirement": ">= 1.0.0 <2.0.0" }
+    { "name": "stahnma/epel",  "version_requirement": ">= 1.0.0 <2.0.0" },
+    { "name": "puppetlabs/stdlib",  "version_requirement": ">= 4.0.0 <5.0.0" },
+    { "name": "puppetlabs/concat",  "version_requirement": ">= 1.0.0 <2.0.0" }
   ],
   "operatingsystem_support": [
     {

--- a/spec/defines/awscli_profile_spec.rb
+++ b/spec/defines/awscli_profile_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+describe 'awscli::profile', :type => :define do
+  context 'supported OS ' do
+    ['darwin', 'debian', 'redhat'].each do |osfamily|
+      describe "#{osfamily} installation" do
+        let(:facts) { {
+          :osfamily => osfamily,
+          :concat_basedir => '/var/lib/puppet/concat/'
+        } }
+
+        let(:title) { 'test_profile' }
+
+        let(:params) { { } }
+
+        it 'should report an error if no aws_access_key_id is given' do
+          is_expected.to raise_error(Puppet::Error, /no aws_access_key_id provided/)
+        end
+
+        it 'should report an error if no aws_secret_access_key is given' do
+          params.merge!({ 'aws_access_key_id' => 'TESTAWSACCESSKEYID' })
+          is_expected.to raise_error(Puppet::Error, /no aws_secret_access_key provided/)
+        end
+
+        it 'should create profile for root if no user is given' do
+          params.merge!({
+            'aws_access_key_id' => 'TESTAWSACCESSKEYID',
+            'aws_secret_access_key' => 'TESTSECRETACCESSKEY'
+          })
+          is_expected.to contain_file('/root/.aws').with_ensure('directory')
+          is_expected.to contain_concat('/root/.aws/credentials')
+          is_expected.to contain_concat__fragment( 'test_profile' ).with
+          ({
+            :target =>  '/root/.aws/credentials'
+          })
+        end
+
+        it 'should create profile for user test' do
+          params.merge!({
+            'user'                  => 'test',
+            'aws_access_key_id'     => 'TESTAWSACCESSKEYID',
+            'aws_secret_access_key' => 'TESTSECRETACCESSKEY'
+          })
+          is_expected.to contain_file('/home/test/.aws').with_ensure('directory')
+          is_expected.to contain_concat('/home/test/.aws/credentials')
+          is_expected.to contain_concat__fragment( 'test_profile' ).with
+          ({
+            :target =>  '/home/test/.aws/credentials'
+          })
+        end
+
+
+      end
+    end
+  end
+end

--- a/templates/credentials_concat.erb
+++ b/templates/credentials_concat.erb
@@ -1,0 +1,5 @@
+[<%=@title%>]
+aws_access_key_id=<%=@aws_access_key_id%>
+aws_secret_access_key=<%=@aws_secret_access_key%>
+
+

--- a/tests/vagrant.pp
+++ b/tests/vagrant.pp
@@ -1,1 +1,6 @@
 class { 'awscli': version => 'latest' }
+awscli::profile { 'default':
+  user                  => 'vagrant',
+  aws_access_key_id     => 'MYTESTACCESSKEYID',
+  aws_secret_access_key => 'MYTESTSECRETACCESSKEY'
+}


### PR DESCRIPTION
the current implementation lacks the ability to add (multiple) aws credentials. 
this PR adds the ability to add credentials for aws cli called "profiles"