### PR TITLE
Homedirs on Darwin usually reside in /Users

### DIFF
--- a/manifests/profile.pp
+++ b/manifests/profile.pp
@@ -26,7 +26,10 @@ define awscli::profile(
   }
 
   if $user != 'root' {
-    $homedir = "/home/${user}"
+    $homedir = $::osfamily? {
+      'Darwin' => "/Users/${user}",
+      default  => "/home/${user}"
+    }
   } else {
     $homedir = '/root'
   }

--- a/spec/defines/awscli_profile_spec.rb
+++ b/spec/defines/awscli_profile_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'awscli::profile', :type => :define do
-  context 'supported OS ' do
-    ['darwin', 'debian', 'redhat'].each do |osfamily|
+  context 'on supported operatingsystems' do
+    [ 'darwin', 'debian', 'redhat'].each do |osfamily|
       describe "#{osfamily} installation" do
         let(:facts) { {
           :osfamily => osfamily,
@@ -21,12 +21,26 @@ describe 'awscli::profile', :type => :define do
           params.merge!({ 'aws_access_key_id' => 'TESTAWSACCESSKEYID' })
           is_expected.to raise_error(Puppet::Error, /no aws_secret_access_key provided/)
         end
+      end
+    end
+  end
+
+  context 'on supported Linux distributions' do
+    [ 'debian', 'redhat'].each do |osfamily|
+      describe "#{osfamily} installation" do
+        let(:facts) { {
+          :osfamily => osfamily,
+          :concat_basedir => '/var/lib/puppet/concat/'
+        } }
+
+        let(:title) { 'test_profile' }
+
+        let(:params) { {
+          'aws_access_key_id'     => 'TESTAWSACCESSKEYID',
+          'aws_secret_access_key' => 'TESTSECRETACCESSKEY'
+        } }
 
         it 'should create profile for root if no user is given' do
-          params.merge!({
-            'aws_access_key_id' => 'TESTAWSACCESSKEYID',
-            'aws_secret_access_key' => 'TESTSECRETACCESSKEY'
-          })
           is_expected.to contain_file('/root/.aws').with_ensure('directory')
           is_expected.to contain_concat('/root/.aws/credentials')
           is_expected.to contain_concat__fragment( 'test_profile' ).with
@@ -38,8 +52,6 @@ describe 'awscli::profile', :type => :define do
         it 'should create profile for user test' do
           params.merge!({
             'user'                  => 'test',
-            'aws_access_key_id'     => 'TESTAWSACCESSKEYID',
-            'aws_secret_access_key' => 'TESTSECRETACCESSKEY'
           })
           is_expected.to contain_file('/home/test/.aws').with_ensure('directory')
           is_expected.to contain_concat('/home/test/.aws/credentials')
@@ -48,9 +60,31 @@ describe 'awscli::profile', :type => :define do
             :target =>  '/home/test/.aws/credentials'
           })
         end
-
-
       end
+    end
+  end
+
+  context 'on Darwin' do
+    let(:facts) { {
+      :osfamily => 'Darwin',
+      :concat_basedir => '/var/lib/puppet/concat/'
+    } }
+
+    let(:title) { 'test_profile' }
+
+    let(:params) { {
+        'user'                  => 'test',
+        'aws_access_key_id'     => 'TESTAWSACCESSKEYID',
+        'aws_secret_access_key' => 'TESTSECRETACCESSKEY'
+    } }
+
+    it 'should create profile for user test' do
+      is_expected.to contain_file('/Users/test/.aws').with_ensure('directory')
+      is_expected.to contain_concat('/Users/test/.aws/credentials')
+      is_expected.to contain_concat__fragment( 'test_profile' ).with
+      ({
+        :target =>  '/Users/test/.aws/credentials'
+      })
     end
   end
 end


### PR DESCRIPTION
As homedirs on Darwin are usually created in /Users, and as /home
is not present by default on Darwin, a distinction should be made
when adding a profile.