### PR TITLE
Add ability to specify homedir

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,19 @@ awscli::profile {
 }
 ```
 
+If the user has a non-standard `${HOME}` location (`/home/${USER}` on Linux,
+`/Users/${USER}` on Mac OS X are considered the standard locations), you can specify the homedir explicitly:
+
+```
+awscli::profile {
+  'default':
+    user                  => 'ubuntu',
+    homedir               => '/tmp',
+    aws_access_key_id     => 'MYAWSACCESSKEYID',
+    aws_secret_access_key => 'MYAWSSECRETACESSKEY'
+}
+```
+
 ## Testing
 You can test this module with rspec:
 

--- a/spec/defines/awscli_profile_spec.rb
+++ b/spec/defines/awscli_profile_spec.rb
@@ -78,6 +78,19 @@ describe 'awscli::profile', :type => :define do
             :target =>  '/home/test/.aws/credentials'
           })
         end
+
+        it 'should create profile for user test with homedir /tmp' do
+          params.merge!({
+            'user'    => 'test',
+            'homedir' => '/tmp'      
+          })
+          is_expected.to contain_file('/tmp/.aws')
+          is_expected.to contain_concat('/tmp/.aws/credentials')
+          is_expected.to contain_concat__fragment( 'test_profile' ).with(
+          {
+            :target =>  '/tmp/.aws/credentials'
+          })
+        end
       end
     end
   end
@@ -111,6 +124,18 @@ describe 'awscli::profile', :type => :define do
       is_expected.to contain_concat__fragment( 'test_profile' ).with(
       {
         :target =>  '/Users/test/.aws/credentials'
+      })
+    end
+    it 'should create profile for user test with homedir /tmp' do
+      params.merge!({
+        'user'    => 'test',
+        'homedir' => '/tmp'      
+      })
+      is_expected.to contain_file('/tmp/.aws')
+      is_expected.to contain_concat('/tmp/.aws/credentials')
+      is_expected.to contain_concat__fragment( 'test_profile' ).with(
+      {
+        :target =>  '/tmp/.aws/credentials'
       })
     end
   end


### PR DESCRIPTION
As the rules for homedir lookup are rather limited, an extra parameter
could make it easier for users with an alternative homedir location
to use the awscli::profile defined type.