### PR TITLE
add region configuration support

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -1,3 +1,3 @@
 forge 'https://forgeapi.puppetlabs.com'
 
-metadata
+

--- a/manifests/profile.pp
+++ b/manifests/profile.pp
@@ -17,6 +17,7 @@ define awscli::profile(
   $homedir               = undef,
   $aws_access_key_id     = undef,
   $aws_secret_access_key = undef,
+  $aws_region            = undef,
 ) {
   if $aws_access_key_id == undef {
     fail ('no aws_access_key_id provided')
@@ -64,8 +65,23 @@ define awscli::profile(
     }
   }
 
-  concat::fragment{ $title:
+  concat::fragment{ "credential-file-append":
     target  => "${homedir_real}/.aws/credentials",
     content => template('awscli/credentials_concat.erb')
+  }
+
+  if $aws_region != undef {
+    if !defined(Concat["${homedir_real}/.aws/config"]) {
+      concat { "${homedir_real}/.aws/config":
+        ensure => 'present',
+        owner  => $user,
+        group  => $group
+      }
+    }
+
+    concat::fragment{ "config-file-append":
+      target  => "${homedir_real}/.aws/config",
+      content => template('awscli/config_concat.erb')
+    }
   }
 }

--- a/spec/defines/awscli_profile_spec.rb
+++ b/spec/defines/awscli_profile_spec.rb
@@ -52,7 +52,7 @@ describe 'awscli::profile', :type => :define do
             :owner  => 'root',
             :group  => 'root'
           })
-          is_expected.to contain_concat__fragment( 'test_profile' ).with(
+          is_expected.to contain_concat__fragment( 'credential-file-append' ).with(
           {
             :target =>  '/root/.aws/credentials'
           })
@@ -73,9 +73,35 @@ describe 'awscli::profile', :type => :define do
             :owner  => 'test',
             :group  => 'test'
           })
-          is_expected.to contain_concat__fragment( 'test_profile' ).with(
+          is_expected.to contain_concat__fragment( 'credential-file-append' ).with(
           {
             :target =>  '/home/test/.aws/credentials'
+          })
+
+          is_expected.to_not contain_concat('/home/test/.aws/config').with(
+          {
+            :owner  => 'test',
+            :group  => 'test'
+          })
+          is_expected.to_not contain_concat__fragment( 'config-file-append' ).with(
+          {
+            :target =>  '/home/test/.aws/config'
+          })
+        end
+
+        it 'should create profile for user test with region' do
+          params.merge!({
+            'user'                  => 'test',
+            'aws_region'            => 'test',
+          })
+          is_expected.to contain_concat('/home/test/.aws/config').with(
+          {
+            :owner  => 'test',
+            :group  => 'test'
+          })
+          is_expected.to contain_concat__fragment( 'config-file-append' ).with(
+          {
+            :target =>  '/home/test/.aws/config'
           })
         end
 
@@ -86,7 +112,7 @@ describe 'awscli::profile', :type => :define do
           })
           is_expected.to contain_file('/tmp/.aws')
           is_expected.to contain_concat('/tmp/.aws/credentials')
-          is_expected.to contain_concat__fragment( 'test_profile' ).with(
+          is_expected.to contain_concat__fragment( 'credential-file-append' ).with(
           {
             :target =>  '/tmp/.aws/credentials'
           })
@@ -121,7 +147,7 @@ describe 'awscli::profile', :type => :define do
         :owner  => 'test',
         :group  => 'staff'
       })
-      is_expected.to contain_concat__fragment( 'test_profile' ).with(
+      is_expected.to contain_concat__fragment( 'credential-file-append' ).with(
       {
         :target =>  '/Users/test/.aws/credentials'
       })
@@ -133,7 +159,7 @@ describe 'awscli::profile', :type => :define do
       })
       is_expected.to contain_file('/tmp/.aws')
       is_expected.to contain_concat('/tmp/.aws/credentials')
-      is_expected.to contain_concat__fragment( 'test_profile' ).with(
+      is_expected.to contain_concat__fragment( 'credential-file-append' ).with(
       {
         :target =>  '/tmp/.aws/credentials'
       })

--- a/templates/config_concat.erb
+++ b/templates/config_concat.erb
@@ -1,0 +1,5 @@
+[<%=@title%>]
+output = text
+region = <%=@aws_region%>
+
+


### PR DESCRIPTION
@justindowning - a little more configuration capability (AWS cli requires a default region for configuration)
since I don't do too much puppet (or Ruby) code, got a little mixed up with the $title thingy, since I'm not sure if it was used only for naming the block, or also as input for the action...

would appreciate feedback, 