### PR TITLE
Add user group

### DIFF
--- a/manifests/profile.pp
+++ b/manifests/profile.pp
@@ -14,6 +14,7 @@
 #
 define awscli::profile(
   $user                  = 'root',
+  $group            = undef,
   $homedir               = undef,
   $aws_access_key_id     = undef,
   $aws_secret_access_key = undef,
@@ -39,20 +40,24 @@ define awscli::profile(
     }
   } 
   
-  if $user != 'root' {
-    $group = $::osfamily? {
-      'Darwin' => 'staff',
-      default  => $user
+  if ($group == undef) {
+    if $user != 'root' {
+      $group_real = $::osfamily? {
+        'Darwin' => 'staff',
+        default  => $user
+      }
+    } else {
+      $group_real = 'root'
     }
   } else {
-    $group = 'root'
+    $group_real = $group
   }
 
   if !defined(File["${homedir_real}/.aws"]) {
     file { "${homedir_real}/.aws":
       ensure => 'directory',
       owner  => $user,
-      group  => $group
+      group  => $group_real
     }
   }
 
@@ -60,7 +65,7 @@ define awscli::profile(
     concat { "${homedir_real}/.aws/credentials":
       ensure => 'present',
       owner  => $user,
-      group  => $group
+      group  => $group_real
     }
   }
 

--- a/spec/defines/awscli_profile_spec.rb
+++ b/spec/defines/awscli_profile_spec.rb
@@ -79,12 +79,46 @@ describe 'awscli::profile', :type => :define do
           })
         end
 
+        it 'should create profile for user test and group testGroup' do
+          params.merge!({
+            'user'                  => 'test',
+            'group'                  => 'testGroup',
+          })
+          is_expected.to contain_file('/home/test/.aws').with(
+          {
+            :ensure => 'directory',
+            :owner  => 'test',
+            :group  => 'testGroup'
+          })
+          is_expected.to contain_concat('/home/test/.aws/credentials').with(
+          {
+            :owner  => 'test',
+            :group  => 'testGroup'
+          })
+        end
+
         it 'should create profile for user test with homedir /tmp' do
           params.merge!({
             'user'    => 'test',
             'homedir' => '/tmp'      
           })
           is_expected.to contain_file('/tmp/.aws')
+          is_expected.to contain_concat('/tmp/.aws/credentials')
+          is_expected.to contain_concat__fragment( 'test_profile' ).with(
+          {
+            :target =>  '/tmp/.aws/credentials'
+          })
+        end
+        it 'should create profile for user test with group testGroup with homedir /tmp' do
+          params.merge!({
+            'user'    => 'test',
+            'group'    => 'testGroup',
+            'homedir' => '/tmp'
+          })
+          is_expected.to contain_file('/tmp/.aws').with({
+            :owner  => 'test',
+            :group  => 'testGroup'
+          })
           is_expected.to contain_concat('/tmp/.aws/credentials')
           is_expected.to contain_concat__fragment( 'test_profile' ).with(
           {
@@ -126,12 +160,49 @@ describe 'awscli::profile', :type => :define do
         :target =>  '/Users/test/.aws/credentials'
       })
     end
+    it 'should create profile for user test and group staff' do
+      params.merge!({
+        'group'    => 'testGroup',
+      })
+      is_expected.to contain_file('/Users/test/.aws').with(
+      {
+        :ensure => 'directory',
+        :owner  => 'test',
+        :group  => 'testGroup'
+      })
+      is_expected.to contain_concat('/Users/test/.aws/credentials').with(
+      {
+        :owner  => 'test',
+        :group  => 'testGroup'
+      })
+      is_expected.to contain_concat__fragment( 'test_profile' ).with(
+      {
+        :target =>  '/Users/test/.aws/credentials'
+      })
+    end
     it 'should create profile for user test with homedir /tmp' do
       params.merge!({
         'user'    => 'test',
         'homedir' => '/tmp'      
       })
       is_expected.to contain_file('/tmp/.aws')
+      is_expected.to contain_concat('/tmp/.aws/credentials')
+      is_expected.to contain_concat__fragment( 'test_profile' ).with(
+      {
+        :target =>  '/tmp/.aws/credentials'
+      })
+    end
+    it 'should create profile for user test with group staff with homedir /tmp' do
+      params.merge!({
+        'user'    => 'test',
+        'group'    => 'testGroup',
+        'homedir' => '/tmp'
+      })
+      is_expected.to contain_file('/tmp/.aws').with(
+      {
+        :owner  => 'test',
+        :group  => 'testGroup'
+      })
       is_expected.to contain_concat('/tmp/.aws/credentials')
       is_expected.to contain_concat__fragment( 'test_profile' ).with(
       {


### PR DESCRIPTION
Add support to enable more control over group. You can now specify specific user group where needed (otherwise everything stays as it was, so this is fully backward compatible).

@willaerk - please check that I did what should be done with Darwin, I assumed users could be assigned a different group? will gladly fix this if needed.