### PR TITLE
Address potential duplicate resource declarations from other modules

### DIFF
--- a/manifests/deps/debian.pp
+++ b/manifests/deps/debian.pp
@@ -3,24 +3,17 @@
 # This module manages awscli dependencies for Debian $::osfamily.
 #
 class awscli::deps::debian {
-#  constraint {
-#    "python-dev-package":
-#      resource  => Package['python-dev'],
-#      allow     => { ensure => ['installed', 'present', 'absent' ] },
-#      weak      => true;
-#  }
-
-#  constraint {
-#    "python-pip-package":
-#      resource  => Package['python-pip'],
-#      allow     => { ensure => ['installed', 'present', 'absent' ] },
-#      weak      => true;
-#  }
-
-  if ! defined(Package['python-dev']) {
-    package { 'python-dev': ensure => installed }
+  constraint {
+    "python-dev-package":
+      resource  => Package['python-dev'],
+      allow     => { ensure => [ 'present' ] },
+      weak      => true;
   }
-  if ! defined(Package['python-pip']) {
-    package { 'python-pip': ensure => installed }
+
+  constraint {
+    "python-pip-package":
+      resource  => Package['python-pip'],
+      allow     => { ensure => [ 'present' ] },
+      weak      => true;
   }
 }

--- a/manifests/deps/debian.pp
+++ b/manifests/deps/debian.pp
@@ -6,12 +6,14 @@ class awscli::deps::debian {
   constraint {
     "python-dev-package":
       resource  => Package['python-dev'],
-      allow     => { ensure => [ 'present' ] };
+      allow     => { ensure => [ 'present' ] },
+      weak      => true;
   }
 
   constraint {
     "python-pip-package":
       resource  => Package['python-pip'],
-      allow     => { ensure => [ 'present' ] };
+      allow     => { ensure => [ 'present' ] },
+      weak      => true;
   }
 }

--- a/manifests/deps/debian.pp
+++ b/manifests/deps/debian.pp
@@ -6,13 +6,15 @@ class awscli::deps::debian {
   constraint {
     "python-dev-package":
       resource  => Package['python-dev'],
-      allow     => { ensure => ['installed', 'present', 'latest' ] };
+      allow     => { ensure => ['installed', 'present', 'latest' ] },
+      weak      => true;
   }
 
   constraint {
     "python-pip-package":
       resource  => Package['python-pip'],
-      allow     => { ensure => ['installed', 'present', 'latest' ] };
+      allow     => { ensure => ['installed', 'present', 'latest' ] },
+      weak      => true;
   }
 
 #  if ! defined(Package['python-dev']) {

--- a/manifests/deps/debian.pp
+++ b/manifests/deps/debian.pp
@@ -3,10 +3,22 @@
 # This module manages awscli dependencies for Debian $::osfamily.
 #
 class awscli::deps::debian {
-  if ! defined(Package['python-dev']) {
-    package { 'python-dev': ensure => installed }
+  constraint {
+    "python-dev-package":
+      resource  => Package['python-dev'],
+      allow     => { ensure => ['installed', 'present', 'latest' ] };
   }
-  if ! defined(Package['python-pip']) {
-    package { 'python-pip': ensure => installed }
+
+  constraint {
+    "python-pip-package":
+      resource  => Package['python-pip'],
+      allow     => { ensure => ['installed', 'present', 'latest' ] };
   }
+
+#  if ! defined(Package['python-dev']) {
+#    package { 'python-dev': ensure => installed }
+#  }
+#  if ! defined(Package['python-pip']) {
+#    package { 'python-pip': ensure => installed }
+#  }
 }

--- a/manifests/deps/debian.pp
+++ b/manifests/deps/debian.pp
@@ -6,14 +6,12 @@ class awscli::deps::debian {
   constraint {
     "python-dev-package":
       resource  => Package['python-dev'],
-      allow     => { ensure => [ 'present' ] },
-      weak      => true;
+      allow     => { ensure => [ 'present' ] };
   }
 
   constraint {
     "python-pip-package":
       resource  => Package['python-pip'],
-      allow     => { ensure => [ 'present' ] },
-      weak      => true;
+      allow     => { ensure => [ 'present' ] };
   }
 }

--- a/manifests/deps/debian.pp
+++ b/manifests/deps/debian.pp
@@ -6,14 +6,14 @@ class awscli::deps::debian {
   constraint {
     "python-dev-package":
       resource  => Package['python-dev'],
-      allow     => { ensure => ['installed', 'present', 'latest' ] },
+      allow     => { ensure => ['installed', 'present', 'absent' ] },
       weak      => true;
   }
 
   constraint {
     "python-pip-package":
       resource  => Package['python-pip'],
-      allow     => { ensure => ['installed', 'present', 'latest' ] },
+      allow     => { ensure => ['installed', 'present', 'absent' ] },
       weak      => true;
   }
 

--- a/manifests/deps/debian.pp
+++ b/manifests/deps/debian.pp
@@ -3,24 +3,24 @@
 # This module manages awscli dependencies for Debian $::osfamily.
 #
 class awscli::deps::debian {
-  constraint {
-    "python-dev-package":
-      resource  => Package['python-dev'],
-      allow     => { ensure => ['installed', 'present', 'absent' ] },
-      weak      => true;
-  }
-
-  constraint {
-    "python-pip-package":
-      resource  => Package['python-pip'],
-      allow     => { ensure => ['installed', 'present', 'absent' ] },
-      weak      => true;
-  }
-
-#  if ! defined(Package['python-dev']) {
-#    package { 'python-dev': ensure => installed }
+#  constraint {
+#    "python-dev-package":
+#      resource  => Package['python-dev'],
+#      allow     => { ensure => ['installed', 'present', 'absent' ] },
+#      weak      => true;
 #  }
-#  if ! defined(Package['python-pip']) {
-#    package { 'python-pip': ensure => installed }
+
+#  constraint {
+#    "python-pip-package":
+#      resource  => Package['python-pip'],
+#      allow     => { ensure => ['installed', 'present', 'absent' ] },
+#      weak      => true;
 #  }
+
+  if ! defined(Package['python-dev']) {
+    package { 'python-dev': ensure => installed }
+  }
+  if ! defined(Package['python-pip']) {
+    package { 'python-pip': ensure => installed }
+  }
 }


### PR DESCRIPTION
I had issues with using your awscli puppet module along with the stankevich/python module. awscli was being included before the python module, and puppet would fail because of duplicate resource declarations. After spending way too much time on figuring out how to address the dependency problem (and finding no good way of doing it), finally landed on the contraints type (https://forge.puppetlabs.com/ffrank/constraints/readme) that tries to address problems with duplicate declarations across modules.

I'm not sure if you want to pull this change. It's probably better going forward, but may be breaking for people currently using your module.

I only updated the debian.pp, not the other ones (osx.pp and redhat.pp), nor did I update the module dependencies.
