### PR TITLE
Adding name param for cli profile name

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ awscli::profile { 'myprofile4':
 ```
 
 Finally, if you'd like to use a different profile name,
-you can specify profile_name directly as a parameter. Note that this is 
+you can specify profile_name directly as a parameter. Note that this is
 a potentially breaking change if you depended on the `$title` for this
 previously:
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ awscli::profile { 'myprofile5':
 The above will result in a file `~ubuntu/.aws/config` that looks like this:
 
 ```
-[foo]
+[profile foo]
 region=eu-west-1
 output=text
 ```

--- a/README.md
+++ b/README.md
@@ -66,12 +66,13 @@ awscli::profile { 'myprofile4':
 ```
 
 Finally, if you'd like to use a different profile name,
-you can specify the name directly as a parameter. Note that this is a potentially breaking
-change if you depended on the `$title` for this previously:
+you can specify profile_name directly as a parameter. Note that this is 
+a potentially breaking change if you depended on the `$title` for this
+previously:
 
 ```
 awscli::profile { 'myprofile5':
-  name                  => 'foo',
+  profile_name          => 'foo',
   user                  => 'ubuntu',
   aws_access_key_id     => 'MYAWSACCESSKEYID',
   aws_secret_access_key => 'MYAWSSECRETACESSKEY'

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You may want to add a credentials for awscli and can do so using `awscli::profil
 If you just define access_key_id and secret key, these credentials will work only for the root user:
 
 ```
-awscli::profile { 'default':
+awscli::profile { 'myprofile':
   aws_access_key_id     => 'MYAWSACCESSKEYID',
   aws_secret_access_key => 'MYAWSSECRETACESSKEY'
 }
@@ -34,7 +34,7 @@ awscli::profile { 'default':
 You can also define a profile for a custom user:
 
 ```
-awscli::profile { 'default':
+awscli::profile { 'myprofile2':
   user                  => 'ubuntu',
   aws_access_key_id     => 'MYAWSACCESSKEYID',
   aws_secret_access_key => 'MYAWSSECRETACESSKEY'
@@ -45,7 +45,7 @@ If the user has a non-standard `${HOME}` location (`/home/${USER}` on Linux,
 `/Users/${USER}` on Mac OS X), you can specify the homedir explicitly:
 
 ```
-awscli::profile { 'default':
+awscli::profile { 'myprofile3':
   user                  => 'ubuntu',
   homedir               => '/tmp',
   aws_access_key_id     => 'MYAWSACCESSKEYID',
@@ -56,13 +56,44 @@ awscli::profile { 'default':
 You can also define the profile's region and output format:
 
 ```
-awscli::profile { 'default':
+awscli::profile { 'myprofile4':
   user                  => 'ubuntu',
   aws_access_key_id     => 'MYAWSACCESSKEYID',
   aws_secret_access_key => 'MYAWSSECRETACESSKEY'
   aws_region            => 'eu-west-1',
   output                => 'text',
 }
+```
+
+Finally, if you'd like to use a different profile name,
+you can specify the name directly as a parameter. Note that this is a potentially breaking
+change if you depended on the `$title` for this previously:
+
+```
+awscli::profile { 'myprofile5':
+  name                  => 'foo',
+  user                  => 'ubuntu',
+  aws_access_key_id     => 'MYAWSACCESSKEYID',
+  aws_secret_access_key => 'MYAWSSECRETACESSKEY'
+  aws_region            => 'eu-west-1',
+  output                => 'text',
+}
+```
+
+The above will result in a file `~ubuntu/.aws/config` that looks like this:
+
+```
+[foo]
+region=eu-west-1
+output=text
+```
+
+and a file `~ubuntu/.aws/credentials` that looks like this:
+
+```
+[foo]
+aws_access_key_id=MYAWSACCESSKEYID
+aws_secret_access_key=MYAWSSECRETACESSKEY
 ```
 
 If you do not provide `aws::profile::aws_access_key_id` and `awscli::profile::aws_secret_access_key`,

--- a/manifests/profile.pp
+++ b/manifests/profile.pp
@@ -25,17 +25,22 @@
 #   The aws_region for this profile
 #   Default: us-east-1
 #
+# [$name]
+#   The name of the AWS profile
+#   Default: default
+#
 # [$output]
 #   The output format used for this profile
 #   Default: json
 #
 # === Example
 #
-# awscli::profile { 'default':
+# awscli::profile { 'tsmith-awscli':
 #   user                  => 'tsmith',
 #   aws_access_key_id     => 'access_key',
 #   aws_secret_access_key => 'secret_key',
 #   aws_region            => 'us-west-2',
+#   name                  => 'default',
 #   output                => 'text',
 # }
 #
@@ -46,6 +51,7 @@ define awscli::profile(
   $aws_access_key_id     = undef,
   $aws_secret_access_key = undef,
   $aws_region            = 'us-east-1',
+  $name                  = 'default',
   $output                = 'json',
 ) {
   if $aws_access_key_id == undef and $aws_secret_access_key == undef {

--- a/manifests/profile.pp
+++ b/manifests/profile.pp
@@ -25,7 +25,7 @@
 #   The aws_region for this profile
 #   Default: us-east-1
 #
-# [$name]
+# [$profile_name]
 #   The name of the AWS profile
 #   Default: default
 #
@@ -40,7 +40,7 @@
 #   aws_access_key_id     => 'access_key',
 #   aws_secret_access_key => 'secret_key',
 #   aws_region            => 'us-west-2',
-#   name                  => 'default',
+#   profile_name          => 'default',
 #   output                => 'text',
 # }
 #
@@ -51,7 +51,7 @@ define awscli::profile(
   $aws_access_key_id     = undef,
   $aws_secret_access_key = undef,
   $aws_region            = 'us-east-1',
-  $name                  = 'default',
+  $profile_name          = 'default',
   $output                = 'json',
 ) {
   if $aws_access_key_id == undef and $aws_secret_access_key == undef {

--- a/templates/config_concat.erb
+++ b/templates/config_concat.erb
@@ -1,3 +1,3 @@
-[<%= @title %>]
+[<%= @name %>]
 region=<%= @aws_region %>
 output=<%= @output %>

--- a/templates/config_concat.erb
+++ b/templates/config_concat.erb
@@ -1,3 +1,3 @@
-[<%= @name %>]
+[<%= @profile_name %>]
 region=<%= @aws_region %>
 output=<%= @output %>

--- a/templates/credentials_concat.erb
+++ b/templates/credentials_concat.erb
@@ -1,3 +1,3 @@
-[<%= @title %>]
+[<%= @name %>]
 aws_access_key_id=<%= @aws_access_key_id %>
 aws_secret_access_key=<%= @aws_secret_access_key %>

--- a/templates/credentials_concat.erb
+++ b/templates/credentials_concat.erb
@@ -1,3 +1,3 @@
-[<%= @name %>]
+[<%= @profile_name %>]
 aws_access_key_id=<%= @aws_access_key_id %>
 aws_secret_access_key=<%= @aws_secret_access_key %>


### PR DESCRIPTION
This is in reference to issue #22 and allows users to specify an AWS profile name as a param. This is a potentially breaking change though, for users that expect `$title` to do what `$profile_name` now does. I looked through your tests and I believe that this will still pass all of them as you didn't appear to be checking for the profile name itself anywhere. If I'm wrong, I'm assuming your CI will pick it up.