### PR TITLE
add booleans for installing pkgdeps or pip

### DIFF
--- a/manifests/deps/debian.pp
+++ b/manifests/deps/debian.pp
@@ -3,10 +3,15 @@
 # This module manages awscli dependencies for Debian $::osfamily.
 #
 class awscli::deps::debian {
-  if ! defined(Package[ $awscli::pkg_dev ]) {
-    package { $awscli::pkg_dev: ensure => installed }
+  if $install_pkgdeps {
+    if ! defined(Package[ $awscli::pkg_dev ]) {
+      package { $awscli::pkg_dev: ensure => installed }
+    }
   }
-  if ! defined(Package[ $awscli::pkg_pip ]) {
-    package { $awscli::pkg_pip: ensure => installed }
+
+  if $install_pip {
+    if ! defined(Package[ $awscli::pkg_pip ]) {
+      package { $awscli::pkg_pip: ensure => installed }
+    }
   }
 }

--- a/manifests/deps/osx.pp
+++ b/manifests/deps/osx.pp
@@ -3,10 +3,14 @@
 # This module manages awscli dependencies for Darwin $::osfamily.
 #
 class awscli::deps::osx {
-  if ! defined(Package[ $awscli::pkg_dev ]) {
-    package { $awscli::pkg_dev: ensure => installed, provider => homebrew }
+  if $install_pkgdeps {
+    if ! defined(Package[ $awscli::pkg_dev ]) {
+      package { $awscli::pkg_dev: ensure => installed, provider => homebrew }
+    }
   }
-  if ! defined(Package[ $awscli::pkg_pip ]) {
-    package { $awscli::pkg_pip: ensure => installed, provider => homebrew }
+  if $install_pip {
+    if ! defined(Package[ $awscli::pkg_pip ]) {
+      package { $awscli::pkg_pip: ensure => installed, provider => homebrew }
+    }
   }
 }

--- a/manifests/deps/redhat.pp
+++ b/manifests/deps/redhat.pp
@@ -6,10 +6,14 @@ class awscli::deps::redhat {
   include ::epel
   Package { require => Class['epel'] }
 
-  if ! defined(Package[ $awscli::pkg_dev ]) {
-    package { $awscli::pkg_dev: ensure => installed }
+  if $install_pkgdeps {
+    if ! defined(Package[ $awscli::pkg_dev ]) {
+      package { $awscli::pkg_dev: ensure => installed }
+    }
   }
-  if ! defined(Package[ $awscli::pkg_pip ]) {
-    package { $awscli::pkg_pip: ensure => installed }
+  if $install_pip {
+    if ! defined(Package[ $awscli::pkg_pip ]) {
+      package { $awscli::pkg_pip: ensure => installed }
+    }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,6 +19,14 @@
 #    Default: See awscli::params Class
 #    This variable is optional.
 #
+#  [$install_pkgdeps]
+#    Boolean flag to install the package dependencies or not
+#    Default: true
+#
+#  [$install_pip]
+#    Boolean flag to install pip or not
+#    Default: true
+#
 # === Examples
 #
 #  class { awscli: }
@@ -32,9 +40,11 @@
 # Copyright 2014 Justin Downing
 #
 class awscli (
-  $version = 'present',
-  $pkg_dev = $awscli::params::pkg_dev,
-  $pkg_pip = $awscli::params::pkg_pip
+  $version          = 'present',
+  $pkg_dev          = $awscli::params::pkg_dev,
+  $pkg_pip          = $awscli::params::pkg_pip,
+  $install_pkgdeps  = true,
+  $install_pip      = true,
 ) inherits awscli::params {
   include awscli::deps
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -51,6 +51,9 @@ class awscli (
   package { 'awscli':
     ensure   => $version,
     provider => 'pip',
-    require  => Class['awscli::deps'],
+    require  => [
+      Package['python-pip'],  
+      Class['awscli::deps'],
+    ],
   }
 }


### PR DESCRIPTION
I ran into another module that didn't check for defined(Package['pip']) and it caused a resource conflict. I added parameters to this to skip the installation of pip if needed as my environment already has it installed via another module.