### PR TITLE
Allow to pass the profile name to use

### DIFF
--- a/manifests/profile.pp
+++ b/manifests/profile.pp
@@ -47,6 +47,7 @@ define awscli::profile(
   $aws_secret_access_key = undef,
   $aws_region            = 'us-east-1',
   $output                = 'json',
+  $profile_name          = $title,
 ) {
   if $aws_access_key_id == undef and $aws_secret_access_key == undef {
     info ('AWS keys for awscli::profile. Your will need IAM roles configured.')

--- a/templates/config_concat.erb
+++ b/templates/config_concat.erb
@@ -1,3 +1,3 @@
-[<%= @title %>]
+[<%= @profile_name %>]
 region=<%= @aws_region %>
 output=<%= @output %>

--- a/templates/credentials_concat.erb
+++ b/templates/credentials_concat.erb
@@ -1,3 +1,3 @@
-[<%= @title %>]
+[<%= @profile_name %>]
 aws_access_key_id=<%= @aws_access_key_id %>
 aws_secret_access_key=<%= @aws_secret_access_key %>


### PR DESCRIPTION
For example, you may want to setup awscli::profile for several user accounts. For every user, the title must be unique:

  awscli::profile { "awscli default profile for $user": ... }

Using the new $profile_name var, you can now manage the "default" profile (for example) for all users.