### PR TITLE
Make awscli compatible with puppetlabs-concat 2.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -12,7 +12,7 @@
   "dependencies": [
     { "name": "stahnma/epel",  "version_requirement": ">= 1.0.0 <2.0.0" },
     { "name": "puppetlabs/stdlib",  "version_requirement": ">= 4.0.0 <5.0.0" },
-    { "name": "puppetlabs/concat",  "version_requirement": ">= 1.0.0 <2.0.0" }
+    { "name": "puppetlabs/concat",  "version_requirement": ">= 1.0.0 <3.0.0" }
   ],
   "operatingsystem_support": [
     {


### PR DESCRIPTION
Concat module is developed in the 2.x branch, and awsci module works fine with concat 2.1.0