### PR TITLE
Fix packages/pip dependencies

### DIFF
--- a/manifests/deps/debian.pp
+++ b/manifests/deps/debian.pp
@@ -3,13 +3,13 @@
 # This module manages awscli dependencies for Debian $::osfamily.
 #
 class awscli::deps::debian {
-  if $install_pkgdeps {
+  if $awscli::install_pkgdeps {
     if ! defined(Package[ $awscli::pkg_dev ]) {
       package { $awscli::pkg_dev: ensure => installed }
     }
   }
 
-  if $install_pip {
+  if $awscli::install_pip {
     if ! defined(Package[ $awscli::pkg_pip ]) {
       package { $awscli::pkg_pip: ensure => installed }
     }

--- a/manifests/deps/osx.pp
+++ b/manifests/deps/osx.pp
@@ -3,12 +3,12 @@
 # This module manages awscli dependencies for Darwin $::osfamily.
 #
 class awscli::deps::osx {
-  if $install_pkgdeps {
+  if $awscli::install_pkgdeps {
     if ! defined(Package[ $awscli::pkg_dev ]) {
       package { $awscli::pkg_dev: ensure => installed, provider => homebrew }
     }
   }
-  if $install_pip {
+  if $awscli::install_pip {
     if ! defined(Package[ $awscli::pkg_pip ]) {
       package { $awscli::pkg_pip: ensure => installed, provider => homebrew }
     }

--- a/manifests/deps/redhat.pp
+++ b/manifests/deps/redhat.pp
@@ -6,12 +6,12 @@ class awscli::deps::redhat {
   include ::epel
   Package { require => Class['epel'] }
 
-  if $install_pkgdeps {
+  if $awscli::install_pkgdeps {
     if ! defined(Package[ $awscli::pkg_dev ]) {
       package { $awscli::pkg_dev: ensure => installed }
     }
   }
-  if $install_pip {
+  if $awscli::install_pip {
     if ! defined(Package[ $awscli::pkg_pip ]) {
       package { $awscli::pkg_pip: ensure => installed }
     }


### PR DESCRIPTION
Currently the dependencies are completely broken, and awscli doesn't even work complaining about missing `Package['pypthon-pip']`. This is because the deps manifests are not using the fully qualified variable, but using a local one that doesn't exist. This PR fixes that