### PR TITLE
Use pip pkg name variable as dep

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -52,7 +52,7 @@ class awscli (
     ensure   => $version,
     provider => 'pip',
     require  => [
-      Package['python-pip'],  
+      Package[$pkg_pip],
       Class['awscli::deps'],
     ],
   }


### PR DESCRIPTION
This way we can really customize pip package name, otherwise it throws a dependency error