### PR TITLE
Add install_options parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ OSX has been tested on Yosemite only and requires:
 
 `class { 'awscli': }`
 
+There are some optional class parameters, documentation can be found in [init.pp](manifests/init.pp).
+
 ### Profiles
 
 You may want to add a credentials for awscli and can do so using `awscli::profile`.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -60,24 +60,13 @@ class awscli (
     proxy => $proxy,
   }
 
-  if $install_options != undef {
-    package { 'awscli':
-      ensure          => $version,
-      provider        => 'pip',
-      install_options => $install_options,
-      require         => [
-        Package[$pkg_pip],
-        Class['awscli::deps'],
-      ],
-    }
-  } else {
-    package { 'awscli':
-      ensure   => $version,
-      provider => 'pip',
-      require  => [
-        Package[$pkg_pip],
-        Class['awscli::deps'],
-      ],
-    }
+  package { 'awscli':
+    ensure          => $version,
+    provider        => 'pip',
+    install_options => $install_options,
+    require         => [
+      Package[$pkg_pip],
+      Class['awscli::deps'],
+    ],
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,6 +31,10 @@
 #    String proxy variable for use with EPEL module
 #    Default: undef
 #
+#  [$install_options]
+#    Array of install options for the awscli Pip package
+#    Default: undef
+#
 # === Examples
 #
 #  class { awscli: }
@@ -50,17 +54,30 @@ class awscli (
   $install_pkgdeps  = true,
   $install_pip      = true,
   $proxy            = $awscli::params::proxy,
+  $install_options  = $awscli::params::install_options,
 ) inherits awscli::params {
-  class { 'awscli::deps':
+  class { '::awscli::deps':
     proxy => $proxy,
   }
 
-  package { 'awscli':
-    ensure   => $version,
-    provider => 'pip',
-    require  => [
-      Package[$pkg_pip],
-      Class['awscli::deps'],
-    ],
+  if $install_options != undef {
+    package { 'awscli':
+      ensure          => $version,
+      provider        => 'pip',
+      install_options => $install_options,
+      require         => [
+        Package[$pkg_pip],
+        Class['awscli::deps'],
+      ],
+    }
+  } else {
+    package { 'awscli':
+      ensure   => $version,
+      provider => 'pip',
+      require  => [
+        Package[$pkg_pip],
+        Class['awscli::deps'],
+      ],
+    }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,6 +6,7 @@
 class awscli::params {
 
   $proxy = undef
+  $install_options = undef
 
   case $::osfamily {
     'Debian': {

--- a/spec/classes/awscli_spec.rb
+++ b/spec/classes/awscli_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'awscli', :type => 'class' do
-  context 'supported OS ' do
+  context 'supported OS' do
     ['darwin', 'debian', 'redhat'].each do |osfamily|
       describe "#{osfamily} installation" do
         let(:facts) { { :osfamily => osfamily } }
@@ -11,6 +11,18 @@ describe 'awscli', :type => 'class' do
         it do should contain_package('awscli').with(
           'ensure'   => 'present',
           'provider' => 'pip',
+          'install_options' => nil,
+        ) end
+      end
+
+      describe "proxy pip setup" do
+        let(:facts) { { :osfamily => 'debian' } }
+        let(:params) { { :install_options => ['--proxy foo'] } }
+
+        it do should contain_package('awscli').with(
+          'ensure'   => 'present',
+          'provider' => 'pip',
+          'install_options' => ['--proxy foo'],
         ) end
       end
     end


### PR DESCRIPTION
I want this feature to support `install_options => [ { '--proxy' => $our_proxy_value, } ]`.

The implementation in `init.pp` is pretty ugly. The only way I know to have an optional class parameter maybe passed to the package resource is duplicating the resource in code 😱 . Is there a better way?