### PR TITLE
On amazon linux must specify version for python-devel

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,7 +14,12 @@ class awscli::params {
       $pkg_pip = 'python-pip'
     }
     'RedHat': {
-      $pkg_dev = 'python-devel'
+        if  $::operatingsystem == 'Amazon' {
+             $pkg_dev = 'python27-devel'
+        } else {
+             $pkg_dev = 'python-devel'
+        }
+     
       if $::operatingsystemrelease =~ /^7/ {
         $pkg_pip = 'python2-pip'
       } else {


### PR DESCRIPTION
Hi Amazon linux is a bit weird.  It wouldn't install package python-devel, so your module was failing.

After forcing python-devel version to 2.7 everything is working great