### PR TITLE
Make profile name behave like documentation

### DIFF
--- a/manifests/profile.pp
+++ b/manifests/profile.pp
@@ -72,7 +72,7 @@ define awscli::profile(
   $source_profile        = undef,
   $role_session_name     = undef,
   $aws_region            = 'us-east-1',
-  $profile_name          = 'default',
+  $profile_name          = $title,
   $output                = 'json',
 ) {
   if $aws_access_key_id == undef and $aws_secret_access_key == undef {


### PR DESCRIPTION
The docs make it look like that a profile name is retrieved from the resource's title, but this isn't the case in use. Instead, an explicit profile_name declaration has to be set. This makes the resource behave like the documentation.