### PR TITLE
Use 'contain' in awscli::deps to avoid out-of-order execution.

### DIFF
--- a/manifests/deps.pp
+++ b/manifests/deps.pp
@@ -15,15 +15,16 @@ class awscli::deps (
 ) inherits awscli::params {
   case $::osfamily {
     'Debian': {
-      include awscli::deps::debian
+      contain awscli::deps::debian
     }
     'RedHat': {
       class { 'awscli::deps::redhat':
         proxy => $proxy,
       }
+      contain awscli::deps::redhat
     }
     'Darwin': {
-      include awscli::deps::osx
+      contain awscli::deps::osx
     }
     default:  { fail("The awscli module does not support ${::osfamily}") }
   }


### PR DESCRIPTION
Currently, awscli can attempt to install the awscli package before pip is installed, resulting in failures on a first puppet run.  This change sets awscli::deps to contain awscli::deps::<os>, to ensure correct execution order.