### PR TITLE
Drop stdlib dependency, allow concat v8.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -13,12 +13,8 @@
       "version_requirement": ">= 3.0.0 <3.99.0"
     },
     {
-      "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.0.0 <7.0.0"
-    },
-    {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 2.0.0 <7.0.0"
+      "version_requirement": ">= 2.0.0 <8.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION

From looking at the code in this repo, I don't see why the puppetlabs/stdlib ﻿dependency is necessary at all.

It seems the dependency was added in https://github.com/jdowning/puppet-awscli/commit/3da4a036a23e70b7ec3588c36ed879b5c55f8cd6 for puppetlabs/concat, but since that would make it a transitive dependency, it should be handled as such (i. e. left to the tooling to resolve).

Stepping from concat 7.x to 8.x seems to cause no relevant changes.

Closes #72.

